### PR TITLE
(master) Extend default stamp accessors to work with "stamp" message field

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,19 @@ using PoseStampedSubscriberType = flow_ros::Subscriber<geometry_msgs::PoseStampe
 
 Default data sequencing within `flow_ros::Subscriber` buffers is performed using message header stamps. Namely, messages are ordered using `ros::Time`. Time offsets are specified with `ros::Duration`.
 
-The Flow library describes how to implement [custom](https://github.com/fetchrobotics/flow#dispatch) access traits objects for dealing with data sequencing. Following this scheme, a default set of traits and accessors are provided in [`message_stamp_access.h`](flow_ros/include/message_stamp_access.h) which assume that messages have `MsgType::header::stamp`. Messages which do not have a `header`, but do have a `ros::Time` member are usable (in addition to those which work by default) after defining the appropriate companion accessors. For example, one can implement specialized access for a particular message like so:
+The Flow library describes how to implement [custom](https://github.com/fetchrobotics/flow#dispatch) access traits objects for dealing with data sequencing. Following this scheme, a default set of traits and accessors are provided in [`message_stamp_access.h`](flow_ros/include/message_stamp_access.h) which assume that messages have `MsgType::header::stamp` or `MsgType::stamp` (of type `ros::Time`). Messages which do not have a `header`, but do have a `ros::Time` member (named something other than `stamp`) are also usable after defining the appropriate companion accessors. For example, one can implement specialized access for a particular message like so:
 
+###### Example Message Definition
+`CustomMessageType.msg`
+```
+time custom_stamp_field_name
+
+...
+
+# other fields #
+```
+
+###### Access specialization
 ```c++
 namespace flow
 {
@@ -129,13 +140,15 @@ template <> struct DispatchAccess<boost::shared_ptr<const CustomMessageType>>
 {
   using CustomMessageConstPtr = boost::shared_ptr<const CustomMessageType>;
 
-  static const ros::Time& stamp(const CustomMessageConstPtr& msg) { return msg->ros_time_stamp; }
+  static const ros::Time& stamp(const CustomMessageConstPtr& msg) { return msg->custom_stamp_field_name; }
 
   static const CustomMessageConstPtr& value(const CustomMessageConstPtr& msg) { return msg; }
 };
 
 }  // namespace flow
 ```
+
+##### Default Sequence Number Accessor
 
 When using `flow_ros::Subscriber` objects directly, you may also opt to use sequence numbers for data ordering. Default handling for this is provided by [`message_seq_access.h`](flow_ros/include/message_seq_access.h).
 

--- a/flow_ros/include/message_stamp_access.h
+++ b/flow_ros/include/message_stamp_access.h
@@ -41,7 +41,6 @@ template <typename MsgT> struct StampSetter
   inline void operator()(MsgT& msg, const ros::Time& stamp) const { msg.header.stamp = stamp; }
 };
 
-
 /**
  * @brief Helper function use to set message stamp with StampSetter
  *
@@ -59,6 +58,22 @@ template <typename MsgT> inline void set_stamp(MsgT&& msg, const ros::Time& stam
  * @brief Defines default message accessors to use a fall-back when defining <code>flow::DispatchAccess</code>
  */
 struct DefaultMessageStampDispatchAccess
+{
+  /**
+   * @brief Returns message stamp, assuming a <code>stamp</code> field exists
+   */
+  template <typename MsgPtrT> inline static const ros::Time& stamp(const MsgPtrT& message) { return message->stamp; }
+
+  /**
+   * @brief Returns reference to message resource pointer (pass-through)
+   */
+  template <typename MsgPtrT> inline static const MsgPtrT& value(const MsgPtrT& message) { return message; }
+};
+
+/**
+ * @brief Defines default message accessors to use a fall-back when defining <code>flow::DispatchAccess</code>
+ */
+struct DefaultMessageHeaderStampDispatchAccess
 {
   /**
    * @brief Returns message stamp, assuming a <code>header.stamp</code> field exists
@@ -79,6 +94,53 @@ struct DefaultMessageStampDispatchAccess
 
 namespace flow
 {
+namespace detail
+{
+
+/**
+ * @brief Extract message value type from message pointer
+ */
+template <typename MsgT> struct MsgType;
+template <typename MsgT> struct MsgType<boost::shared_ptr<const MsgT>>
+{
+  using type = MsgT;
+};
+template <typename MsgT> struct MsgType<std::shared_ptr<const MsgT>>
+{
+  using type = MsgT;
+};
+
+/// Helper used to check if <code>MsgT::stamp</code> of type <code>ros::Time</code> exists
+template <typename MsgT> struct has_member_stamp
+{
+  // Dummy template, used to evaluate within argument list
+  template <typename C, C> struct TryEval;
+
+  // This method is called if 'MsgT::header' is available
+  template <typename C> static constexpr std::true_type test_fn(TryEval<ros::Time MsgT::*, &C::stamp>*);
+
+  // This method called as a fall-back if above "test_fn" is ignore due to SFINAE
+  template <typename C> static constexpr std::false_type test_fn(...);
+
+  static constexpr bool value = std::is_same<decltype(test_fn<MsgT>(nullptr)), std::true_type>::value;
+};
+
+/// Helper used to check if <code>MsgT::header</code> of type <code>std_msgs::Header</code> exists
+template <typename MsgT> struct has_member_header
+{
+  // Dummy template, used to evaluate within argument list
+  template <typename C, C> struct TryEval;
+
+  // This method is called if 'MsgT::header' is available
+  template <typename C> static constexpr std::true_type test_fn(TryEval<std_msgs::Header MsgT::*, &C::header>*);
+
+  // This method called as a fall-back if above "test_fn" is ignore due to SFINAE
+  template <typename C> static constexpr std::false_type test_fn(...);
+
+  static constexpr bool value = std::is_same<decltype(test_fn<MsgT>(nullptr)), std::true_type>::value;
+};
+
+}  // namespace detail
 
 /**
  * @brief ROS timing type traits for associated message Dispatch
@@ -130,8 +192,18 @@ template <typename MsgT> struct DispatchTraits<std::shared_ptr<const MsgT>>
  *
  * @tparam MsgT  message type
  */
-template <typename MsgT> struct DispatchAccess : ::flow_ros::DefaultMessageStampDispatchAccess
-{};
+template <typename MsgT>
+struct DispatchAccess : std::conditional_t<
+                          detail::has_member_stamp<typename detail::MsgType<MsgT>::type>::value,
+                          ::flow_ros::DefaultMessageStampDispatchAccess,
+                          ::flow_ros::DefaultMessageHeaderStampDispatchAccess>
+{
+  FLOW_STATIC_ASSERT(
+    !(detail::has_member_stamp<typename detail::MsgType<MsgT>::type>::value and
+      detail::has_member_header<typename detail::MsgType<MsgT>::type>::value),
+    "Default access implementation detects both 'ros::Time stamp' and 'std_msgs::Header header' members. "
+    "Please specialize 'DispatchAccess' for your message type to disambiguate.");
+};
 
 }  // namespace flow
 


### PR DESCRIPTION
- `DispatchAccess` will detect for the existence of either
     + `ros::Time stamp`
     + `std_msgs::Header header`
- It will force compilation failure if there is an exact match (type and name) for both fields
- Updates README