### PR TITLE
(master) Update StampSetter to work with additional default msg access

### DIFF
--- a/flow_ros/include/impl/event_handler.hpp
+++ b/flow_ros/include/impl/event_handler.hpp
@@ -84,21 +84,6 @@ private:
 
 
 /**
- * @brief Helper function use to set message sequencing stamp
- *
- * @tparam MsgT  (deduced) message type
- * @tparam SeqT  (deduced) sequencing type
- *
- * @param msg  message
- * @param seq  message sequence counter
- */
-template <typename MsgT, typename SeqT> inline void set_stamp(MsgT&& msg, SeqT&& seq)
-{
-  StampSetter<MsgT>{}(std::forward<MsgT>(msg), std::forward<SeqT>(seq));
-}
-
-
-/**
  * @brief Helper object used to publish 1 or N outputs from an EventHandler
  */
 class EventHandlerPublishHelper

--- a/flow_ros/include/publisher.h
+++ b/flow_ros/include/publisher.h
@@ -12,6 +12,7 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 // ROS
@@ -258,6 +259,22 @@ public:
    */
   inline void publish(const OutputContainerT& messages) const { publish(std::begin(messages), std::end(messages)); }
 };
+
+
+/**
+ * @brief Helper function use to set message sequencing stamp
+ *
+ * @tparam MsgT  (deduced) message type
+ * @tparam SeqT  (deduced) sequencing type
+ *
+ * @param msg  message
+ * @param seq  message sequence counter
+ */
+template <typename MsgT, typename SeqT> inline void set_stamp(MsgT&& msg, SeqT&& seq)
+{
+  using CleanedMsgT = std::remove_reference_t<MsgT>;
+  StampSetter<CleanedMsgT>{}(std::forward<MsgT>(msg), std::forward<SeqT>(seq));
+}
 
 
 /**


### PR DESCRIPTION
- Default StampSetter needed to set messages with stamp field (outside of header)
- Move flow_ros::set_stamp to publisher.h
     + Remove duplicate in event_handler.hpp impl
     + Make common helper function in more accessible API header